### PR TITLE
Add strange parts and spells fields on item struct

### DIFF
--- a/src/response/listing/attributes.rs
+++ b/src/response/listing/attributes.rs
@@ -1,6 +1,8 @@
 use serde::{Serialize, Deserialize};
-use tf2_enum::{StrangePart, Rarity};
+use tf2_enum::{StrangePart, Rarity, Spell};
+use crate::response::serializers::to_display;
 use crate::response::deserializers::{
+    from_str,
     from_number_or_string,
     map_to_enum,
 };
@@ -92,6 +94,15 @@ pub struct RecipeAttribute {
     pub target_item: Option<TargetItem>,
     #[serde(default)]
     pub output_item: Option<Box<Item>>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SpellAttribute {
+    #[serde(rename = "name")]
+    #[serde(serialize_with = "to_display")]
+    #[serde(deserialize_with = "from_str")]
+    spell: Spell,
 }
 
 #[cfg(test)]

--- a/src/response/listing/item.rs
+++ b/src/response/listing/item.rs
@@ -68,5 +68,7 @@ pub struct Item {
     #[serde(default)]
     #[serde(deserialize_with = "from_optional_number_or_string")]
     pub quantity: Option<u32>,
+    pub strange_parts: Option<Vec<attributes::KillEaterAttribute>>,
+    pub spells: Option<Vec<attributes::SpellAttribute>>,
 }
 

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -10,4 +10,5 @@ pub mod alert;
 pub mod currencies;
 pub mod classifieds_limits;
 
+pub mod serializers;
 pub mod deserializers;

--- a/src/response/serializers.rs
+++ b/src/response/serializers.rs
@@ -1,0 +1,6 @@
+use std::fmt::Display;
+use serde::ser::Serializer;
+
+pub fn to_display<T, S>(item: T, serializer: S) -> Result<S::Ok, S::Error> where T: Display, S: Serializer {
+    serializer.serialize_str(&item.to_string())
+}


### PR DESCRIPTION
For the strange parts field I just used KillEaterAttribute since the actual values are pretty much the same, it just doesn't include kill eaters 'built in' to the item.

For the spells field I had to make a serializer for tf2_enum::Spell, I just used the fmt::Display implementation.