### PR TITLE
Add features for native TLS and rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-util = { version = "0.3", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 http = { version = "0.2.9", optional = true }
 data-encoding = { version = "2.3.3", optional = true }
-rand = { verison = "0.8.5", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 [features]
 websocket = ["dep:tokio", "dep:http", "dep:rand", "dep:data-encoding", "dep:tokio-tungstenite", "dep:futures-util", "dep:serde_bytes", "serde_json/raw_value"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 serde-enum-str = "0.3"
-reqwest = { version = "^0.11", features = ["json", "cookies"] }
+reqwest = { version = "^0.11", features = ["json", "cookies"], default-features = false }
 reqwest-retry = "^0.1"
 reqwest-middleware = "^0.1"
 url = "^2.2"
@@ -31,7 +31,7 @@ tf2-enum = "^0.8"
 tf2-price = "^0.11"
 log = "0.4.17"
 tokio = { version = "1", features = ["sync"], optional = true }
-tokio-tungstenite = { version = "0.17", features = ["native-tls"], optional = true }
+tokio-tungstenite = { version = "0.17", optional = true }
 futures-util = { version = "0.3", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 http = { version = "0.2.9", optional = true }
@@ -39,6 +39,10 @@ data-encoding = { version = "2.3.3", optional = true }
 rand = { version = "0.8.5", optional = true }
 
 [features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls", "tokio-tungstenite?/native-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots", "tokio-tungstenite?/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots", "tokio-tungstenite?/rustls-tls-webpki-roots"]
 websocket = ["dep:tokio", "dep:http", "dep:rand", "dep:data-encoding", "dep:tokio-tungstenite", "dep:futures-util", "dep:serde_bytes", "serde_json/raw_value"]
 
 [dev-dependencies]


### PR DESCRIPTION
Adds features for native TLS and rustls to allow switching between them. I'm finding this useful in cross compilation scenarios.