### PR TITLE
websocket: Expose websocket event ID

### DIFF
--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -3,10 +3,10 @@ use backpacktf_api::websocket::{Error, connect};
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let mut websocket = connect().await?;
-    
-    while let Some(message) = websocket.recv().await {
-        println!("{message:?}");
+
+    while let Some((id, message)) = websocket.recv().await {
+        println!("{id}: {message:?}");
     }
-    
+
     Ok(())
 }


### PR DESCRIPTION
Exposes websocket event ID to websocket reader. This breaks API compatibility by changing the message type for the websocket channel from `Message` to `(String, Message)`. Useful for deduplication of events if running multiple instances of an application, or for deriving timestamps from event IDs.